### PR TITLE
Feature/zc simulator

### DIFF
--- a/infotainment/headunit/package-lock.json
+++ b/infotainment/headunit/package-lock.json
@@ -7319,9 +7319,9 @@
             }
         },
         "node_modules/caniuse-lite": {
-            "version": "1.0.30001651",
-            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001651.tgz",
-            "integrity": "sha512-9Cf+Xv1jJNe1xPZLGuUXLNkE1BoDkqRqYyFJ9TDYSqhduqA4hu4oR9HluGoWYQC/aj8WHjsGVV+bwkh0+tegRg==",
+            "version": "1.0.30001718",
+            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001718.tgz",
+            "integrity": "sha512-AflseV1ahcSunK53NfEs9gFWgOEmzr0f+kaMFA4xiLZlr9Hzt7HxcSpIFcnNCUkz6R6dWKa54rUz3HUmI3nVcw==",
             "funding": [
                 {
                     "type": "opencollective",

--- a/zc/zc_simulator/__main__.py
+++ b/zc/zc_simulator/__main__.py
@@ -39,15 +39,60 @@ def smooth_throttle_iterator():
         # Round to 1 decimal place
         yield round(value, 1)
 
+def smooth_rpm_iterator():
+    """Generate smooth RPM values that oscillate between 0 and 1500"""
+    value = 0
+    step = 50  # Controls the smoothness of transition
+    direction = 1  # 1 for increasing, -1 for decreasing
+    
+    while True:
+        # Change direction when reaching limits
+        if value >= 1500:
+            direction = -1
+        elif value <= 0:
+            direction = 1
+            
+        # Update value
+        value += step * direction
+        # Ensure value stays in range [0, 1500]
+        value = max(0.0, min(1500.0, value))
+        # Round to nearest integer
+        yield int(value)
+
+def smooth_battery_iterator():
+    """Generate smooth battery values that oscillate between  and 1500"""
+    value = 67.2
+    step = 0.05  # Controls the smoothness of transition
+    direction = -1  # 1 for increasing, -1 for decreasing
+    
+    while True:
+        # Change direction when reaching limits
+        if value >= 67.2:
+            direction = -1
+        elif value <= 51.6:
+            direction = 1
+            
+        # Update value
+        value += step * direction
+        # Ensure value stays in range [0, 1500]
+        value = max(51.6, min(67.2, value))
+        # Round to nearest integer
+        yield int(value)
+
 
 with connect("ws://localhost:6969") as websocket:
     websocket.send(json.dumps(create_register_packet("throttle")))
+    websocket.send(json.dumps(create_register_packet("battery")))
     throttle_gen = smooth_throttle_iterator()
+    rpm_gen = smooth_rpm_iterator()
+    battery_gen = smooth_battery_iterator()
     
     while True:
         throttle_value = next(throttle_gen)
-        print(f"Throttle: {throttle_value}")
+        rpm_value = next(rpm_gen)
+        battery_value = next(battery_gen)
+        print(f"Throttle: {throttle_value} RPM: {rpm_value} Battery: {battery_value}")
         websocket.send(json.dumps(create_data_packet("throttle", "getThrottle", [throttle_value, throttle_value])))
+        websocket.send(json.dumps(create_data_packet("throttle", "getRpm", rpm_value)))
+        websocket.send(json.dumps(create_data_packet("battery", "getVoltage", battery_value)))
         time.sleep(0.3 * random.random())  # Sleep for 100ms between messages
-
-

--- a/zc/zc_simulator/__main__.py
+++ b/zc/zc_simulator/__main__.py
@@ -1,0 +1,53 @@
+import json
+import numpy as np
+from websockets.sync.client import connect
+import time
+import random
+
+# JSON data model for a zone controller register message
+
+# ReigsterPacket
+
+def create_register_packet(zone: str):
+    return {
+        "zone": zone,
+    }
+
+def create_data_packet(zone: str, command: str, value):
+    return {
+        "zone": zone,
+        "command": command,
+        "value": value
+    }
+def smooth_throttle_iterator():
+    """Generate smooth throttle values that oscillate between 0 and 1"""
+    value = 0.0
+    step = 0.05  # Controls the smoothness of transition
+    direction = 1  # 1 for increasing, -1 for decreasing
+    
+    while True:
+        # Change direction when reaching limits
+        if value >= 1.0:
+            direction = -1
+        elif value <= 0.0:
+            direction = 1
+            
+        # Update value
+        value += step * direction
+        # Ensure value stays in range [0, 1]
+        value = max(0.0, min(1.0, value))
+        # Round to 1 decimal place
+        yield round(value, 1)
+
+
+with connect("ws://localhost:6969") as websocket:
+    websocket.send(json.dumps(create_register_packet("throttle")))
+    throttle_gen = smooth_throttle_iterator()
+    
+    while True:
+        throttle_value = next(throttle_gen)
+        print(f"Throttle: {throttle_value}")
+        websocket.send(json.dumps(create_data_packet("throttle", "getThrottle", [throttle_value, throttle_value])))
+        time.sleep(0.3 * random.random())  # Sleep for 100ms between messages
+
+


### PR DESCRIPTION
This pull request includes updates to the `zc_simulator` to add functionality for generating smooth data streams for throttle, RPM, and battery values, and sending them over a WebSocket connection. Additionally, it includes a minor dependency update in the `infotainment/headunit/package-lock.json` file.

### Simulator Enhancements:
* [`zc/zc_simulator/__main__.py`](diffhunk://#diff-10ae67f549360de716ca1c5db3bd19cadde0a389bba69a1f762ebec02bdf8345R1-R98): Added functions to generate smooth oscillating values for throttle, RPM, and battery levels (`smooth_throttle_iterator`, `smooth_rpm_iterator`, `smooth_battery_iterator`). These values are sent as JSON packets over a WebSocket connection to simulate real-time data updates.

### Dependency Updates:
* [`infotainment/headunit/package-lock.json`](diffhunk://#diff-452402ede36d28f7740bc6f93740dc3a73e50e1315fe0fe5f6a8f61fc3f4a43fL7322-R7324): Updated the `caniuse-lite` dependency from version `1.0.30001651` to `1.0.30001718`, including changes to the resolved URL and integrity hash.