### PR TITLE
feat: remove deprecated Discord auth; add NEXTAUTH_URL env var;

### DIFF
--- a/analytics/.env.example
+++ b/analytics/.env.example
@@ -15,9 +15,9 @@
 # https://next-auth.js.org/configuration/options#secret
 AUTH_SECRET=""
 
-# Next Auth Discord Provider
-AUTH_DISCORD_ID=""
-AUTH_DISCORD_SECRET=""
+# Next Auth URL
+# (set to localhost for IDE and to external URL for PROD)
+NEXTAUTH_URL="http://localhost"
 
 # Next Auth GitHub Provider
 AUTH_GITHUB_ID=""

--- a/analytics/src/env.js
+++ b/analytics/src/env.js
@@ -11,8 +11,7 @@ export const env = createEnv({
       process.env.NODE_ENV === "production"
         ? z.string()
         : z.string().optional(),
-    AUTH_DISCORD_ID: z.string(),
-    AUTH_DISCORD_SECRET: z.string(),
+    NEXTAUTH_URL: z.string(),
     AUTH_GITHUB_ID: z.string(),
     AUTH_GITHUB_SECRET: z.string(),
     DATABASE_URL: z.string().url(),
@@ -40,8 +39,7 @@ export const env = createEnv({
    */
   runtimeEnv: {
     AUTH_SECRET: process.env.AUTH_SECRET,
-    AUTH_DISCORD_ID: process.env.AUTH_DISCORD_ID,
-    AUTH_DISCORD_SECRET: process.env.AUTH_DISCORD_SECRET,
+    NEXTAUTH_URL: process.env.NEXTAUTH_URL,
     AUTH_GITHUB_ID: process.env.AUTH_GITHUB_ID,
     AUTH_GITHUB_SECRET: process.env.AUTH_GITHUB_SECRET,
     DATABASE_URL: process.env.DATABASE_URL,

--- a/analytics/src/server/auth/config.ts
+++ b/analytics/src/server/auth/config.ts
@@ -1,6 +1,5 @@
 import { PrismaAdapter } from "@auth/prisma-adapter";
 import { type DefaultSession, type NextAuthConfig } from "next-auth";
-import DiscordProvider from "next-auth/providers/discord";
 import GitHubProvider from "next-auth/providers/github";
 
 import { db } from "@/server/db";
@@ -33,7 +32,6 @@ declare module "next-auth" {
  */
 export const authConfig = {
   providers: [
-    DiscordProvider,
     GitHubProvider
     /**
      * ...add more providers here.


### PR DESCRIPTION
This pull request updates the authentication configuration for the analytics service, removing Discord authentication support and introducing a new required environment variable for the NextAuth URL. The focus is on simplifying the authentication setup to use only GitHub as a provider and updating the environment configuration accordingly.

Authentication provider changes:
* Removed Discord authentication provider from the NextAuth configuration in `config.ts`, so users can now only authenticate using GitHub. [[1]](diffhunk://#diff-ec2bacd64f81380434b5893dd3f3d731c9c4fdfa2b1feb600e97c389fc54534fL3) [[2]](diffhunk://#diff-ec2bacd64f81380434b5893dd3f3d731c9c4fdfa2b1feb600e97c389fc54534fL36)

Environment variable updates:
* Removed `AUTH_DISCORD_ID` and `AUTH_DISCORD_SECRET` from `.env.example` and replaced them with a new `NEXTAUTH_URL` variable, which should be set differently for local development and production.
* Updated the environment validation and runtime configuration in `env.js` to remove Discord-related variables and add `NEXTAUTH_URL` as a required variable. [[1]](diffhunk://#diff-0f6b711e4d6cbc417e541b311b70fd635608a0660b1b27be1a73aed727a35ee9L14-R14) [[2]](diffhunk://#diff-0f6b711e4d6cbc417e541b311b70fd635608a0660b1b27be1a73aed727a35ee9L43-R42)