### PR TITLE
feat: add configurable analytics backend URL and connection checks

### DIFF
--- a/infotainment/headunit/src/helpers/analytics_helpers.ts
+++ b/infotainment/headunit/src/helpers/analytics_helpers.ts
@@ -4,7 +4,7 @@ import { BatteryCommands, ThrottleCommands, Zones } from "@/data/zonecontrollers
 import { stringify } from "querystring";
 
 
-const ANALYTICS_BACKEND_URL = "http://localhost:3000/api/gokart"; // Replace with actual URL
+let analyticsBackendUrl = "http://localhost:3000/api/gokart";
 const COMMAND_RATE_LIMITS: Record<string, number> = {
     [ThrottleCommands.GET_THROTTLE]: 100,
     [ThrottleCommands.GET_RPM]: 100,
@@ -13,6 +13,29 @@ const COMMAND_RATE_LIMITS: Record<string, number> = {
 
 let analyticsEnabled = false;
 const lastSentTimestamps: Record<string, number> = {};
+
+export function setAnalyticsBackendUrl(url: string): void {
+    analyticsBackendUrl = url;
+}
+
+export function getAnalyticsBackendUrl(): string {
+    return analyticsBackendUrl;
+}
+
+export async function checkAnalyticsConnection(url: string): Promise<boolean> {
+    try {
+        const controller = new AbortController();
+        const timeout = setTimeout(() => controller.abort(), 5000);
+        const response = await fetch(url, {
+            method: 'GET',
+            signal: controller.signal,
+        });
+        clearTimeout(timeout);
+        return response.ok;
+    } catch {
+        return false;
+    }
+}
 
 export function toggleAnalytics(enabled: boolean): boolean {
     analyticsEnabled = enabled;
@@ -73,7 +96,7 @@ export function processAnalytics(message: string): void {
     lastSentTimestamps[parsedMessage.command] = now;
 
     // Send POST request to analytics backend
-    fetch(`${ANALYTICS_BACKEND_URL}`, {
+    fetch(`${analyticsBackendUrl}`, {
         method: 'POST',
         headers: {
             'Content-Type': 'application/json'

--- a/infotainment/headunit/src/helpers/ipc/application/app-channels.ts
+++ b/infotainment/headunit/src/helpers/ipc/application/app-channels.ts
@@ -1,2 +1,5 @@
 export const APP_VERSION_CHANNEL = "app-version";
 export const APP_TOGGLE_ANALYTICS_CHANNEL = "app-toggle-analytics";
+export const APP_GET_ANALYTICS_URL_CHANNEL = "app-get-analytics-url";
+export const APP_SET_ANALYTICS_URL_CHANNEL = "app-set-analytics-url";
+export const APP_CHECK_ANALYTICS_CONNECTION_CHANNEL = "app-check-analytics-connection";

--- a/infotainment/headunit/src/helpers/ipc/application/app-context.ts
+++ b/infotainment/headunit/src/helpers/ipc/application/app-context.ts
@@ -1,4 +1,4 @@
-import { APP_VERSION_CHANNEL, APP_TOGGLE_ANALYTICS_CHANNEL } from "./app-channels";
+import { APP_VERSION_CHANNEL, APP_TOGGLE_ANALYTICS_CHANNEL, APP_GET_ANALYTICS_URL_CHANNEL, APP_SET_ANALYTICS_URL_CHANNEL, APP_CHECK_ANALYTICS_CONNECTION_CHANNEL } from "./app-channels";
 
 export function exposeAppContext() {
     const { contextBridge, ipcRenderer } = window.require('electron');
@@ -9,6 +9,15 @@ export function exposeAppContext() {
         },
         toggleAnalytics: async (enabled: boolean): Promise<boolean> => {
             return await ipcRenderer.invoke(APP_TOGGLE_ANALYTICS_CHANNEL, enabled);
+        },
+        getAnalyticsUrl: async (): Promise<string> => {
+            return await ipcRenderer.invoke(APP_GET_ANALYTICS_URL_CHANNEL);
+        },
+        setAnalyticsUrl: async (url: string): Promise<string> => {
+            return await ipcRenderer.invoke(APP_SET_ANALYTICS_URL_CHANNEL, url);
+        },
+        checkAnalyticsConnection: async (url: string): Promise<boolean> => {
+            return await ipcRenderer.invoke(APP_CHECK_ANALYTICS_CONNECTION_CHANNEL, url);
         }
     });
 }

--- a/infotainment/headunit/src/helpers/ipc/application/app-listeners.ts
+++ b/infotainment/headunit/src/helpers/ipc/application/app-listeners.ts
@@ -1,6 +1,6 @@
 import { app, ipcMain } from "electron";
-import { APP_TOGGLE_ANALYTICS_CHANNEL, APP_VERSION_CHANNEL } from "./app-channels";
-import { toggleAnalytics } from "@/helpers/analytics_helpers";
+import { APP_TOGGLE_ANALYTICS_CHANNEL, APP_VERSION_CHANNEL, APP_GET_ANALYTICS_URL_CHANNEL, APP_SET_ANALYTICS_URL_CHANNEL, APP_CHECK_ANALYTICS_CONNECTION_CHANNEL } from "./app-channels";
+import { toggleAnalytics, getAnalyticsBackendUrl, setAnalyticsBackendUrl, checkAnalyticsConnection } from "@/helpers/analytics_helpers";
 
 export function addAppEventListeners() {
     ipcMain.handle(APP_VERSION_CHANNEL, async () => {
@@ -8,5 +8,15 @@ export function addAppEventListeners() {
     });
     ipcMain.handle(APP_TOGGLE_ANALYTICS_CHANNEL, async (_, enabled) => {
         return toggleAnalytics(enabled);
-    })
+    });
+    ipcMain.handle(APP_GET_ANALYTICS_URL_CHANNEL, async () => {
+        return getAnalyticsBackendUrl();
+    });
+    ipcMain.handle(APP_SET_ANALYTICS_URL_CHANNEL, async (_, url: string) => {
+        setAnalyticsBackendUrl(url);
+        return getAnalyticsBackendUrl();
+    });
+    ipcMain.handle(APP_CHECK_ANALYTICS_CONNECTION_CHANNEL, async (_, url: string) => {
+        return checkAnalyticsConnection(url);
+    });
 }

--- a/infotainment/headunit/src/pages/settings.tsx
+++ b/infotainment/headunit/src/pages/settings.tsx
@@ -2,6 +2,7 @@ import LabeledSwitch from "@/components/shared/labeled-switch";
 import TabsSelector from "@/components/shared/tabs-selector";
 import { Label } from "@/components/ui/label";
 import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
 import { Slider } from "@/components/ui/slider"
 import {
   Dialog,
@@ -21,12 +22,17 @@ import { toast } from "sonner";
 import AvancedSettingsDialog from "@/components/shared/advanced-settings/advanced-settings-dialog";
 import AdminSettingsDialog from "@/components/admin-mode/admin-settings-dialog";
 import React, { useEffect } from "react";
+import { Loader2, Check, X } from "lucide-react";
 import PowerMenu from "@/components/power-menu/power-menu";
 
 const SettingsPage = () => {
 
-  const { driveMode, adminMode, speedLimit, minSettableSpeed, maxSettableSpeed, appVersion, analyticsEnabled } = useStore();
-  const { setDriveMode, setAdminMode, setAdminPin, setSpeedLimit, setAppVersion, setAnalyticsEnabled } = useStore();
+  const { driveMode, adminMode, speedLimit, minSettableSpeed, maxSettableSpeed, appVersion, analyticsEnabled, analyticsBackendUrl } = useStore();
+  const { setDriveMode, setAdminMode, setAdminPin, setSpeedLimit, setAppVersion, setAnalyticsEnabled, setAnalyticsBackendUrl } = useStore();
+
+  const [urlInput, setUrlInput] = React.useState(analyticsBackendUrl);
+  const [connectionStatus, setConnectionStatus] = React.useState<"idle" | "checking" | "success" | "error">("idle");
+  const [analyticsDialogOpen, setAnalyticsDialogOpen] = React.useState(false);
 
 //  const [speedLimitUiLabel, setSpeedLimitUiLabel] = React.useState(speedLimit);
 
@@ -45,7 +51,17 @@ const SettingsPage = () => {
       console.error(e);
       }
     };
+    const fetchAnalyticsUrl = async () => {
+      try {
+        const url = await window.app.getAnalyticsUrl();
+        setAnalyticsBackendUrl(url);
+        setUrlInput(url);
+      } catch (e) {
+        console.error(e);
+      }
+    };
     fetchAppVersion();
+    fetchAnalyticsUrl();
   }, []);
 
   let handleToggleAnalytics = (enabled: boolean) => {
@@ -54,6 +70,31 @@ const SettingsPage = () => {
         setAnalyticsEnabled(result);
         toast(`Cloud Analytics ${result ? "enabled" : "disabled"}!`);
       });
+  }
+
+  let handleCheckConnection = async () => {
+    setConnectionStatus("checking");
+    try {
+      const ok = await window.app.checkAnalyticsConnection(urlInput);
+      setConnectionStatus(ok ? "success" : "error");
+    } catch {
+      setConnectionStatus("error");
+    }
+  }
+
+  let handleSaveAnalyticsUrl = async () => {
+    const savedUrl = await window.app.setAnalyticsUrl(urlInput);
+    setAnalyticsBackendUrl(savedUrl);
+    setAnalyticsDialogOpen(false);
+    toast("Analytics Backend URL updated!");
+  }
+
+  let handleAnalyticsDialogOpenChange = (open: boolean) => {
+    setAnalyticsDialogOpen(open);
+    if (open) {
+      setUrlInput(analyticsBackendUrl);
+      setConnectionStatus("idle");
+    }
   }
 
 
@@ -74,6 +115,49 @@ const SettingsPage = () => {
             />
           <LabeledSwitch id="airplane-mode" label="Airplane Mode" defaultValue={false} />
           <LabeledSwitch id="on-by-default" label="On by Default" defaultValue={true} />
+          <div className="flex flex-row justify-between items-center space-x-4">
+              <Label htmlFor="analytics-backend" className="text-base mr-5">Analytics Backend</Label>
+              <Dialog open={analyticsDialogOpen} onOpenChange={handleAnalyticsDialogOpenChange}>
+                <DialogTrigger asChild>
+                  <Button variant="outline">Configure</Button>
+                </DialogTrigger>
+                <DialogContent>
+                  <DialogHeader>
+                    <DialogTitle>Analytics Backend URL</DialogTitle>
+                  </DialogHeader>
+                  <DialogDescription>
+                    Set the URL of the analytics backend. Connection must be verified before saving.
+                    <Separator className="mt-3" />
+                  </DialogDescription>
+                  <div className="flex flex-col gap-y-4">
+                    <div className="flex flex-row items-center gap-x-2">
+                      <Input
+                        placeholder="http://localhost:3000/api/gokart"
+                        value={urlInput}
+                        onChange={(e) => {
+                          setUrlInput(e.target.value);
+                          setConnectionStatus("idle");
+                        }}
+                      />
+                      {connectionStatus === "success" && <Check className="text-green-500 shrink-0" size={20} />}
+                      {connectionStatus === "error" && <X className="text-red-500 shrink-0" size={20} />}
+                      {connectionStatus === "checking" && <Loader2 className="animate-spin text-muted-foreground shrink-0" size={20} />}
+                    </div>
+                    {connectionStatus === "error" && (
+                      <p className="text-sm text-red-500">Connection failed. Please check the URL and try again.</p>
+                    )}
+                    <div className="flex flex-row justify-end gap-x-2">
+                      <Button variant="outline" onClick={handleCheckConnection} disabled={connectionStatus === "checking" || !urlInput}>
+                        {connectionStatus === "checking" ? "Checking..." : "Check Connection"}
+                      </Button>
+                      <Button onClick={handleSaveAnalyticsUrl} disabled={connectionStatus !== "success"}>
+                        Save
+                      </Button>
+                    </div>
+                  </div>
+                </DialogContent>
+              </Dialog>
+          </div>
         </div>
         {/* ### 2. Einstellungsblock ### */}
         <div className="flex flex-col items-left justify-center gap-y-2 ms-16">

--- a/infotainment/headunit/src/stores/systemSlice.ts
+++ b/infotainment/headunit/src/stores/systemSlice.ts
@@ -6,11 +6,13 @@ export interface SystemSlice {
     adminMode: boolean,
     appVersion: string,
     analyticsEnabled: boolean,
+    analyticsBackendUrl: string,
     showParticleEffects: boolean,
     setScreenBrightness: (screenBrightness: number) => void,
     setAdminPin: (adminPin: string) => void,
     setAppVersion: (appVersion: string) => void,
     setAnalyticsEnabled: (analyticsEnabled: boolean) => void,
+    setAnalyticsBackendUrl: (url: string) => void,
     setShowParticleEffects: (showParticleEffects: boolean) => void,
   }
 
@@ -25,10 +27,12 @@ export const createSystemSlice: StateCreator<
     adminMode: false,
     appVersion: "unknown",
     analyticsEnabled: false,
+    analyticsBackendUrl: "http://localhost:3000/api/gokart",
     showParticleEffects: true,
     setScreenBrightness: (screenBrightness: number) => set(() => ({ screenBrightness: screenBrightness })),
     setAdminPin: (adminPin: string) => set(() => ({ adminPin: adminPin })),
     setAppVersion: (appVersion: string) => set(() => ({ appVersion: appVersion })),
     setAnalyticsEnabled: (analyticsEnabled: boolean) => set(() => ({ analyticsEnabled: analyticsEnabled })),
+    setAnalyticsBackendUrl: (analyticsBackendUrl: string) => set(() => ({ analyticsBackendUrl: analyticsBackendUrl })),
     setShowParticleEffects: (showParticleEffects: boolean) => set(() => ({ showParticleEffects: showParticleEffects })),
 })

--- a/infotainment/headunit/src/types.d.ts
+++ b/infotainment/headunit/src/types.d.ts
@@ -34,6 +34,9 @@ interface WebSocketContext {
 interface AppContext {
     getVersion: () => Promise<string>;
     toggleAnalytics: (enabled: boolean) => Promise<boolean>;
+    getAnalyticsUrl: () => Promise<string>;
+    setAnalyticsUrl: (url: string) => Promise<string>;
+    checkAnalyticsConnection: (url: string) => Promise<boolean>;
 }
 
 interface SomeipContext {


### PR DESCRIPTION
This pull request adds the ability to configure the analytics backend URL from the settings page, including verifying the connection before saving. It introduces new IPC channels and supporting logic in both the frontend and backend to get, set, and test the analytics backend URL, and updates the global store to track this value. The settings UI now includes a dialog for editing and validating the analytics backend URL.

**Analytics Backend URL Configuration**

* Added functions to get, set, and check the analytics backend URL in `analytics_helpers.ts`, replacing the constant URL with a mutable value and providing async validation of connectivity. [[1]](diffhunk://#diff-b5e3a6926190822a29289f35f9b9ab7aa3475e5d83bac519b9a7fae16da43138L7-R7) [[2]](diffhunk://#diff-b5e3a6926190822a29289f35f9b9ab7aa3475e5d83bac519b9a7fae16da43138R17-R39) [[3]](diffhunk://#diff-b5e3a6926190822a29289f35f9b9ab7aa3475e5d83bac519b9a7fae16da43138L76-R99)
* Updated the global system store to include `analyticsBackendUrl` and its setter, with default value and type definitions. [[1]](diffhunk://#diff-5445dfadccba821ae8c04db1c8a7ad7cc34dace6d00c8c23cfe865246c82df20R9-R15) [[2]](diffhunk://#diff-5445dfadccba821ae8c04db1c8a7ad7cc34dace6d00c8c23cfe865246c82df20R30-R36)

**IPC and Application Integration**

* Introduced new IPC channels and handlers for getting, setting, and checking the analytics backend URL, wiring them through `app-channels.ts`, `app-context.ts`, and `app-listeners.ts`. [[1]](diffhunk://#diff-a263f218eac2d225ee25a9e0ccad6127bb794e3507d7ae5fd2eeb049cb85b5f7R3-R5) [[2]](diffhunk://#diff-5db077706932e6c50774c942781208d0d483e2ed74d13100dff5edc7fe5d9c56L1-R1) [[3]](diffhunk://#diff-5db077706932e6c50774c942781208d0d483e2ed74d13100dff5edc7fe5d9c56R12-R20) [[4]](diffhunk://#diff-996cb668f3fe34ecfcb7728d45671fb2157a7402915d27fdcef072c65af30865L2-R21)

**Settings Page UI Enhancements**

* Added a dialog to the settings page for configuring the analytics backend URL, including real-time connection checking with user feedback and save functionality. [[1]](diffhunk://#diff-c48ca7804f3ffccfe81903b8f2c4f0aee0d9d4e31f94d43daf24032aecbcaecfR5) [[2]](diffhunk://#diff-c48ca7804f3ffccfe81903b8f2c4f0aee0d9d4e31f94d43daf24032aecbcaecfR25-R35) [[3]](diffhunk://#diff-c48ca7804f3ffccfe81903b8f2c4f0aee0d9d4e31f94d43daf24032aecbcaecfR54-R64) [[4]](diffhunk://#diff-c48ca7804f3ffccfe81903b8f2c4f0aee0d9d4e31f94d43daf24032aecbcaecfR75-R99) [[5]](diffhunk://#diff-c48ca7804f3ffccfe81903b8f2c4f0aee0d9d4e31f94d43daf24032aecbcaecfR118-R160)

These changes make the analytics backend endpoint configurable at runtime, improving flexibility for deployment and testing.