### PR TITLE
Feature/headunit ecu manager

### DIFF
--- a/infotainment/headunit/src/App.tsx
+++ b/infotainment/headunit/src/App.tsx
@@ -12,6 +12,7 @@ import DriveNormalPage from "./pages/drive-normal";
 import SettingsPage from "./pages/settings";
 import CarPage from "./pages/car";
 import BatteryPage from "./pages/battery";
+import EcuManagerPage from "./pages/ecu-manager";
 import { Toaster } from "@/components/ui/sonner"
 import MotorPage from "./pages/motor";
 import { ErrorBoundary } from "@/components/shared/error-boundary";
@@ -72,6 +73,7 @@ export default function App() {
                             <Route path="/car" element={<ErrorBoundary><CarPage /></ErrorBoundary>} />
                             <Route path="/settings" element={<ErrorBoundary><SettingsPage /></ErrorBoundary>} />
                             <Route path="/battery" element={<ErrorBoundary><BatteryPage /></ErrorBoundary>} />
+                            <Route path="/ecu-manager" element={<ErrorBoundary><EcuManagerPage /></ErrorBoundary>} />
                         </Routes>
                     </>
                 </div>

--- a/infotainment/headunit/src/components/ecu/ecu-card.tsx
+++ b/infotainment/headunit/src/components/ecu/ecu-card.tsx
@@ -1,0 +1,46 @@
+import React from "react";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { Cpu } from "lucide-react";
+import { EcuDefinition } from "@/data/ecu/ecu-types";
+import { EcuUpdateDialog } from "./ecu-update-dialog";
+
+interface EcuCardProps {
+    definition: EcuDefinition;
+}
+
+export const EcuCard = ({ definition }: EcuCardProps) => {
+    const cardTrigger = (
+        <Card className="flex flex-col cursor-pointer transition-colors hover:bg-muted/40">
+            <CardHeader className="pb-2 pt-4 px-4">
+                <div className="flex items-center justify-between gap-2">
+                    <div className="flex items-center gap-2 min-w-0">
+                        <Cpu className="h-4 w-4 shrink-0 text-muted-foreground" />
+                        <CardTitle className="text-sm truncate">{definition.displayName}</CardTitle>
+                    </div>
+                    <Badge
+                        variant="outline"
+                        className={
+                            definition.mockOnline
+                                ? "shrink-0 text-green-600 border-green-600"
+                                : "shrink-0 text-muted-foreground"
+                        }
+                    >
+                        {definition.mockOnline ? "Online" : "Offline"}
+                    </Badge>
+                </div>
+            </CardHeader>
+
+            <CardContent className="px-4 pb-4 pt-1">
+                <div className="flex items-center gap-2">
+                    <span className="text-xs text-muted-foreground">Version</span>
+                    <Badge variant="secondary" className="font-mono text-xs">
+                        {definition.mockCurrentVersion}
+                    </Badge>
+                </div>
+            </CardContent>
+        </Card>
+    );
+
+    return <EcuUpdateDialog definition={definition} trigger={cardTrigger} />;
+};

--- a/infotainment/headunit/src/components/ecu/ecu-update-dialog.tsx
+++ b/infotainment/headunit/src/components/ecu/ecu-update-dialog.tsx
@@ -1,0 +1,258 @@
+import React, { useEffect, useState } from "react";
+import {
+    Dialog,
+    DialogContent,
+    DialogDescription,
+    DialogHeader,
+    DialogTitle,
+    DialogTrigger,
+} from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import { Separator } from "@/components/ui/separator";
+import { Loader2, CheckCircle2, XCircle, Download, Zap, HardDrive } from "lucide-react";
+import { toast } from "sonner";
+import log from "@/lib/logger";
+import { EcuDefinition, FirmwareRelease, OtaPhase } from "@/data/ecu/ecu-types";
+import { cn } from "@/lib/utils";
+
+interface EcuUpdateDialogProps {
+    definition: EcuDefinition;
+    trigger: React.ReactNode;
+}
+
+const formatDate = (iso: string) =>
+    new Date(iso).toLocaleDateString("en-US", {
+        year: "numeric",
+        month: "short",
+        day: "numeric",
+    });
+
+export const EcuUpdateDialog = ({ definition, trigger }: EcuUpdateDialogProps) => {
+    const [open, setOpen] = useState(false);
+
+    const [releases, setReleases] = useState<FirmwareRelease[] | null>(null);
+    const [releasesError, setReleasesError] = useState<string | null>(null);
+    const [selectedRelease, setSelectedRelease] = useState<FirmwareRelease | null>(null);
+    const [cachedVersions, setCachedVersions] = useState<string[]>([]);
+
+    const [phase, setPhase] = useState<OtaPhase>(OtaPhase.Idle);
+    const [otaError, setOtaError] = useState<string | null>(null);
+
+    const isFlashing = phase === OtaPhase.Downloading || phase === OtaPhase.Flashing;
+
+    useEffect(() => {
+        if (!open) return;
+
+        setReleases(null);
+        setReleasesError(null);
+        setSelectedRelease(null);
+        setPhase(OtaPhase.Idle);
+        setOtaError(null);
+
+        const load = async () => {
+            try {
+                const [fetchedReleases, allCached] = await Promise.all([
+                    window.firmware.getReleases(definition.githubAssetName),
+                    window.firmware.getCachedVersions(),
+                ]);
+                setReleases(fetchedReleases);
+                setCachedVersions(allCached[definition.id] ?? []);
+            } catch (err) {
+                const msg = err instanceof Error ? err.message : "Failed to fetch releases";
+                log.error("[EcuUpdateDialog] Failed to load:", err);
+                setReleasesError(msg);
+            }
+        };
+
+        load();
+    }, [open, definition.githubAssetName, definition.id]);
+
+    const handleFlash = async () => {
+        if (!selectedRelease) return;
+
+        const isCached = cachedVersions.includes(selectedRelease.tag);
+        setOtaError(null);
+
+        try {
+            if (!isCached) {
+                setPhase(OtaPhase.Downloading);
+                await window.firmware.downloadFirmware(
+                    definition.id,
+                    selectedRelease.tag,
+                    selectedRelease.downloadUrl
+                );
+                setCachedVersions((prev) => [...prev, selectedRelease.tag]);
+            }
+
+            setPhase(OtaPhase.Flashing);
+            const result = await window.firmware.triggerOta(definition.id, selectedRelease.tag);
+
+            if (result.success) {
+                setPhase(OtaPhase.Success);
+                toast.success(`OTA triggered for ${definition.displayName} (${selectedRelease.tag})`);
+            } else {
+                throw new Error("OTA trigger returned failure");
+            }
+        } catch (err) {
+            const msg = err instanceof Error ? err.message : "OTA failed";
+            log.error("[EcuUpdateDialog] OTA failed:", err);
+            setOtaError(msg);
+            setPhase(OtaPhase.Error);
+            toast.error(`OTA failed: ${msg}`);
+        }
+    };
+
+    const getButtonLabel = () => {
+        if (phase === OtaPhase.Downloading) return "Downloading...";
+        if (phase === OtaPhase.Flashing) return "Flashing...";
+        if (phase === OtaPhase.Success) return "Done";
+        if (phase === OtaPhase.Error) return "Retry";
+        if (!selectedRelease) return "Select a version";
+        if (cachedVersions.includes(selectedRelease.tag)) return "Flash";
+        return "Download & Flash";
+    };
+
+    const getButtonIcon = () => {
+        if (isFlashing) return <Loader2 className="mr-2 h-4 w-4 animate-spin" />;
+        if (phase === OtaPhase.Success) return <CheckCircle2 className="mr-2 h-4 w-4" />;
+        if (phase === OtaPhase.Error) return <XCircle className="mr-2 h-4 w-4" />;
+        if (selectedRelease && cachedVersions.includes(selectedRelease.tag))
+            return <Zap className="mr-2 h-4 w-4" />;
+        return <Download className="mr-2 h-4 w-4" />;
+    };
+
+    return (
+        <Dialog
+            open={open}
+            onOpenChange={(v) => {
+                if (!isFlashing) setOpen(v);
+            }}
+        >
+            <DialogTrigger asChild>
+                {trigger}
+            </DialogTrigger>
+
+            <DialogContent className="max-w-lg max-h-[85vh] flex flex-col">
+                <DialogHeader>
+                    <DialogTitle>Flash Firmware: {definition.displayName}</DialogTitle>
+                    <DialogDescription>
+                        Select a release from GitHub to flash over LAN. The headunit will host the
+                        binary and send the URL to the ECU.
+                    </DialogDescription>
+                </DialogHeader>
+
+                <Separator />
+
+                {/* Release list */}
+                <div className="flex-1 min-h-0 flex flex-col gap-2">
+                    <p className="text-xs font-medium text-muted-foreground uppercase tracking-wide">
+                        Available Releases
+                    </p>
+
+                    {!releases && !releasesError && (
+                        <div className="flex items-center justify-center py-8 text-muted-foreground">
+                            <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                            <span className="text-sm">Fetching releases...</span>
+                        </div>
+                    )}
+
+                    {releasesError && (
+                        <div className="rounded-md border border-destructive/50 bg-destructive/10 px-3 py-2 text-sm text-destructive">
+                            {releasesError}
+                        </div>
+                    )}
+
+                    {releases && releases.length === 0 && (
+                        <p className="py-4 text-center text-sm text-muted-foreground">
+                            No releases found for {definition.githubAssetName}
+                        </p>
+                    )}
+
+                    {releases && releases.length > 0 && (
+                        <div className="overflow-y-auto max-h-56 rounded-md border divide-y">
+                            {releases.map((release) => {
+                                const isCached = cachedVersions.includes(release.tag);
+                                const isSelected = selectedRelease?.tag === release.tag;
+                                return (
+                                    <button
+                                        key={release.tag}
+                                        className={cn(
+                                            "w-full text-left px-3 py-2.5 flex items-center justify-between gap-2 transition-colors hover:bg-muted/50",
+                                            isSelected && "bg-muted"
+                                        )}
+                                        onClick={() => {
+                                            if (!isFlashing) {
+                                                setSelectedRelease(release);
+                                                setPhase(OtaPhase.Idle);
+                                                setOtaError(null);
+                                            }
+                                        }}
+                                        disabled={isFlashing}
+                                    >
+                                        <div className="flex flex-col gap-0.5 min-w-0">
+                                            <div className="flex items-center gap-2">
+                                                <span className="font-mono text-sm font-medium">
+                                                    {release.tag}
+                                                </span>
+                                                {release.isPrerelease && (
+                                                    <Badge variant="outline" className="text-yellow-600 border-yellow-500 text-xs px-1.5 py-0">
+                                                        pre-release
+                                                    </Badge>
+                                                )}
+                                            </div>
+                                            <span className="text-xs text-muted-foreground">
+                                                {formatDate(release.publishedAt)}
+                                            </span>
+                                        </div>
+                                        {isCached && (
+                                            <HardDrive className="h-3.5 w-3.5 shrink-0 text-muted-foreground" aria-label="Cached locally" />
+                                        )}
+                                    </button>
+                                );
+                            })}
+                        </div>
+                    )}
+                </div>
+
+                {/* Selected release detail */}
+                {selectedRelease && (
+                    <div className="rounded-md border px-3 py-2 text-xs text-muted-foreground space-y-0.5">
+                        <p className="font-medium text-foreground text-sm">
+                            Selected: {selectedRelease.tag}
+                        </p>
+                        <p>Published: {formatDate(selectedRelease.publishedAt)}</p>
+                        <p className="font-mono break-all">{selectedRelease.downloadUrl}</p>
+                        {cachedVersions.includes(selectedRelease.tag) && (
+                            <p className="text-green-600 dark:text-green-400">Cached locally, ready to flash immediately</p>
+                        )}
+                    </div>
+                )}
+
+                {/* Error message */}
+                {phase === OtaPhase.Error && otaError && (
+                    <div className="rounded-md border border-destructive/50 bg-destructive/10 px-3 py-2 text-sm text-destructive">
+                        {otaError}
+                    </div>
+                )}
+
+                <Separator />
+
+                <div className="flex justify-end">
+                    <Button
+                        disabled={
+                            !selectedRelease ||
+                            isFlashing ||
+                            phase === OtaPhase.Success
+                        }
+                        onClick={handleFlash}
+                        variant={phase === OtaPhase.Error ? "destructive" : "default"}
+                    >
+                        {getButtonIcon()}
+                        {getButtonLabel()}
+                    </Button>
+                </div>
+            </DialogContent>
+        </Dialog>
+    );
+};

--- a/infotainment/headunit/src/components/ui/badge.tsx
+++ b/infotainment/headunit/src/components/ui/badge.tsx
@@ -1,0 +1,36 @@
+import * as React from "react"
+import { cva, type VariantProps } from "class-variance-authority"
+
+import { cn } from "@/lib/utils"
+
+const badgeVariants = cva(
+  "inline-flex items-center rounded-full border px-2.5 py-0.5 text-xs font-semibold transition-colors focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2",
+  {
+    variants: {
+      variant: {
+        default:
+          "border-transparent bg-primary text-primary-foreground hover:bg-primary/80",
+        secondary:
+          "border-transparent bg-secondary text-secondary-foreground hover:bg-secondary/80",
+        destructive:
+          "border-transparent bg-destructive text-destructive-foreground hover:bg-destructive/80",
+        outline: "text-foreground",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+    },
+  }
+)
+
+export interface BadgeProps
+  extends React.HTMLAttributes<HTMLDivElement>,
+    VariantProps<typeof badgeVariants> {}
+
+function Badge({ className, variant, ...props }: BadgeProps) {
+  return (
+    <div className={cn(badgeVariants({ variant }), className)} {...props} />
+  )
+}
+
+export { Badge, badgeVariants }

--- a/infotainment/headunit/src/data/config.ts
+++ b/infotainment/headunit/src/data/config.ts
@@ -4,3 +4,6 @@ export const WEBSOCKET_PORT = process.env.WEBSOCKET_PORT ? parseInt(process.env.
 // SERO service configuration
 export const SERO_UNICAST_PORT = 30491;
 export const SERO_CLIENT_ID = 0x0002;
+
+// Firmware HTTP file server configuration
+export const FIRMWARE_SERVER_PORT = process.env.FIRMWARE_SERVER_PORT ? parseInt(process.env.FIRMWARE_SERVER_PORT, 10) : 8080;

--- a/infotainment/headunit/src/data/ecu/ecu-definitions.ts
+++ b/infotainment/headunit/src/data/ecu/ecu-definitions.ts
@@ -1,0 +1,38 @@
+import { EcuDefinition } from './ecu-types';
+
+/**
+ * TODO: 
+ * This data should all come from the ECUs themselves.
+ * ECUs should report their current firmware version and 
+ * online status via Sero telemetry / self-description on connect.
+ */ 
+export const ECU_DEFINITIONS: EcuDefinition[] = [
+    {
+        id: 'zc_buttons',
+        displayName: 'Button Controller',
+        githubAssetName: 'firmware_zc_buttons.bin',
+        mockCurrentVersion: 'v0.3.1',
+        mockOnline: true,
+    },
+    {
+        id: 'zc_lights',
+        displayName: 'Lights Controller',
+        githubAssetName: 'firmware_zc_lights.bin',
+        mockCurrentVersion: 'v0.4.15',
+        mockOnline: true,
+    },
+    {
+        id: 'zc_battery',
+        displayName: 'Battery Controller',
+        githubAssetName: 'firmware_zc_battery.bin',
+        mockCurrentVersion: 'v0.4.16',
+        mockOnline: false,
+    },
+    {
+        id: 'zc_throttle',
+        displayName: 'Throttle Controller',
+        githubAssetName: 'firmware_zc_throttle.bin',
+        mockCurrentVersion: 'v0.2.0',
+        mockOnline: true,
+    },
+];

--- a/infotainment/headunit/src/data/ecu/ecu-types.ts
+++ b/infotainment/headunit/src/data/ecu/ecu-types.ts
@@ -1,0 +1,40 @@
+export type EcuId = 'zc_buttons' | 'zc_lights' | 'zc_battery' | 'zc_throttle';
+
+
+/**
+ * TODO:
+ * This data should all come from the ECUs themselves.
+ * ECUs should report their current firmware version and 
+ * online status via Sero telemetry / self-description on connect.
+ */
+export interface EcuDefinition {
+    id: EcuId;
+    displayName: string;
+    /** Asset filename in GitHub releases, e.g. "firmware_zc_battery.bin" */
+    githubAssetName: string;
+    /** Mock current firmware version until ECUs report their own */
+    mockCurrentVersion: string;
+    /** Mock online status until real telemetry is available */
+    mockOnline: boolean;
+}
+
+export interface FirmwareRelease {
+    tag: string;
+    version: string;
+    publishedAt: string;
+    downloadUrl: string;
+    isPrerelease: boolean;
+}
+
+export enum OtaPhase {
+    Idle = 'idle',
+    Downloading = 'downloading',
+    Flashing = 'flashing',
+    Success = 'success',
+    Error = 'error',
+}
+
+export interface OtaState {
+    phase: OtaPhase;
+    error?: string;
+}

--- a/infotainment/headunit/src/helpers/ipc/context-exposer.ts
+++ b/infotainment/headunit/src/helpers/ipc/context-exposer.ts
@@ -4,6 +4,7 @@ import { exposeWebSocketContext } from "./websocket/ws-context";
 import { exposeWindowContext } from "./window/window-context";
 import { exposeSeroContext } from "./sero/sero-context";
 import { exposeHardwareContext } from "./hardware/hardware-context";
+import { exposeFirmwareContext } from "./firmware/firmware-context";
 
 export default function exposeContexts() {
     exposeWindowContext();
@@ -12,4 +13,5 @@ export default function exposeContexts() {
     exposeAppContext();
     exposeSeroContext();
     exposeHardwareContext();
+    exposeFirmwareContext();
 }

--- a/infotainment/headunit/src/helpers/ipc/firmware/firmware-channels.ts
+++ b/infotainment/headunit/src/helpers/ipc/firmware/firmware-channels.ts
@@ -1,0 +1,5 @@
+export const FIRMWARE_GET_RELEASES_CHANNEL = 'firmware:get-releases';
+export const FIRMWARE_DOWNLOAD_CHANNEL = 'firmware:download';
+export const FIRMWARE_TRIGGER_OTA_CHANNEL = 'firmware:trigger-ota';
+export const FIRMWARE_GET_SERVER_URL_CHANNEL = 'firmware:get-server-url';
+export const FIRMWARE_GET_CACHED_VERSIONS_CHANNEL = 'firmware:get-cached-versions';

--- a/infotainment/headunit/src/helpers/ipc/firmware/firmware-context.ts
+++ b/infotainment/headunit/src/helpers/ipc/firmware/firmware-context.ts
@@ -1,0 +1,29 @@
+import {
+    FIRMWARE_GET_RELEASES_CHANNEL,
+    FIRMWARE_DOWNLOAD_CHANNEL,
+    FIRMWARE_TRIGGER_OTA_CHANNEL,
+    FIRMWARE_GET_SERVER_URL_CHANNEL,
+    FIRMWARE_GET_CACHED_VERSIONS_CHANNEL,
+} from './firmware-channels';
+
+export function exposeFirmwareContext(): void {
+    const { contextBridge, ipcRenderer } = window.require('electron');
+
+    contextBridge.exposeInMainWorld('firmware', {
+        getReleases: async (assetName: string) => {
+            return ipcRenderer.invoke(FIRMWARE_GET_RELEASES_CHANNEL, assetName);
+        },
+        downloadFirmware: async (ecuId: string, tag: string, downloadUrl: string) => {
+            return ipcRenderer.invoke(FIRMWARE_DOWNLOAD_CHANNEL, ecuId, tag, downloadUrl);
+        },
+        triggerOta: async (ecuId: string, tag: string) => {
+            return ipcRenderer.invoke(FIRMWARE_TRIGGER_OTA_CHANNEL, ecuId, tag);
+        },
+        getServerBaseUrl: async () => {
+            return ipcRenderer.invoke(FIRMWARE_GET_SERVER_URL_CHANNEL);
+        },
+        getCachedVersions: async () => {
+            return ipcRenderer.invoke(FIRMWARE_GET_CACHED_VERSIONS_CHANNEL);
+        },
+    });
+}

--- a/infotainment/headunit/src/helpers/ipc/firmware/firmware-listeners.ts
+++ b/infotainment/headunit/src/helpers/ipc/firmware/firmware-listeners.ts
@@ -1,0 +1,52 @@
+import { ipcMain } from 'electron';
+import log from 'electron-log/main';
+import {
+    FIRMWARE_GET_RELEASES_CHANNEL,
+    FIRMWARE_DOWNLOAD_CHANNEL,
+    FIRMWARE_TRIGGER_OTA_CHANNEL,
+    FIRMWARE_GET_SERVER_URL_CHANNEL,
+    FIRMWARE_GET_CACHED_VERSIONS_CHANNEL,
+} from './firmware-channels';
+import { fetchReleases } from './github-releases';
+import { downloadFirmware, getCachedVersions, getFirmwareLocalUrl, isDownloaded } from './firmware-manager';
+import { getBindAddress } from '@/helpers/ipc/hardware/network-config';
+import { FIRMWARE_SERVER_PORT } from '@/data/config';
+import { EcuId } from '@/data/ecu/ecu-types';
+
+export function registerFirmwareListeners(): void {
+    ipcMain.handle(FIRMWARE_GET_RELEASES_CHANNEL, async (_event, assetName: string) => {
+        return fetchReleases(assetName);
+    });
+
+    ipcMain.handle(FIRMWARE_DOWNLOAD_CHANNEL, async (_event, ecuId: EcuId, tag: string, downloadUrl: string) => {
+        if (isDownloaded(ecuId, tag)) {
+            log.info(`[firmware] ${ecuId} ${tag} already cached, skipping download`);
+            return { localUrl: getFirmwareLocalUrl(ecuId, tag) };
+        }
+        await downloadFirmware(ecuId, tag, downloadUrl);
+        return { localUrl: getFirmwareLocalUrl(ecuId, tag) };
+    });
+
+    ipcMain.handle(FIRMWARE_TRIGGER_OTA_CHANNEL, async (_event, ecuId: EcuId, tag: string) => {
+        const url = getFirmwareLocalUrl(ecuId, tag);
+
+        if (!isDownloaded(ecuId, tag)) {
+            throw new Error(`Firmware ${ecuId} ${tag} is not downloaded. Download it first.`);
+        }
+
+        // TODO: Replace this placeholder with the actual Sero REQUEST call.
+        // The payload should be Buffer.from(url, 'utf-8') sent to the ECU's OTA service/method ID.
+        log.info(`[OTA PLACEHOLDER] Would send OTA URL to ECU ${ecuId}: ${url}`);
+
+        return { success: true, url };
+    });
+
+    ipcMain.handle(FIRMWARE_GET_SERVER_URL_CHANNEL, async () => {
+        const bindAddress = getBindAddress();
+        return `http://${bindAddress}:${FIRMWARE_SERVER_PORT}`;
+    });
+
+    ipcMain.handle(FIRMWARE_GET_CACHED_VERSIONS_CHANNEL, async () => {
+        return getCachedVersions();
+    });
+}

--- a/infotainment/headunit/src/helpers/ipc/firmware/firmware-manager.ts
+++ b/infotainment/headunit/src/helpers/ipc/firmware/firmware-manager.ts
@@ -1,0 +1,89 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import https from 'https';
+import http from 'http';
+import { app } from 'electron';
+import log from 'electron-log/main';
+import { EcuId } from '@/data/ecu/ecu-types';
+import { getBindAddress } from '@/helpers/ipc/hardware/network-config';
+import { FIRMWARE_SERVER_PORT } from '@/data/config';
+
+export function getFirmwarePath(ecuId: EcuId, tag: string): string {
+    return path.join(app.getPath('userData'), 'firmware', ecuId, tag, 'fw.bin');
+}
+
+export function isDownloaded(ecuId: EcuId, tag: string): boolean {
+    return fs.existsSync(getFirmwarePath(ecuId, tag));
+}
+
+export function downloadFirmware(ecuId: EcuId, tag: string, downloadUrl: string): Promise<void> {
+    return new Promise((resolve, reject) => {
+        const filePath = getFirmwarePath(ecuId, tag);
+        const dir = path.dirname(filePath);
+
+        fs.mkdirSync(dir, { recursive: true });
+
+        const file = fs.createWriteStream(filePath);
+        const protocol = downloadUrl.startsWith('https') ? https : http;
+
+        log.info(`[firmware-manager] Downloading ${ecuId} ${tag} from ${downloadUrl}`);
+
+        const request = protocol.get(downloadUrl, (res) => {
+            if (res.statusCode === 302 || res.statusCode === 301) {
+                // Follow redirect (GitHub release assets redirect to S3)
+                file.close();
+                fs.unlinkSync(filePath);
+                downloadFirmware(ecuId, tag, res.headers.location!).then(resolve).catch(reject);
+                return;
+            }
+
+            if (res.statusCode !== 200) {
+                file.close();
+                fs.unlinkSync(filePath);
+                reject(new Error(`Download failed with status ${res.statusCode}`));
+                return;
+            }
+
+            res.pipe(file);
+            file.on('finish', () => {
+                file.close(() => {
+                    log.info(`[firmware-manager] Downloaded ${ecuId} ${tag} to ${filePath}`);
+                    resolve();
+                });
+            });
+        });
+
+        request.on('error', (err) => {
+            file.close();
+            if (fs.existsSync(filePath)) fs.unlinkSync(filePath);
+            reject(err);
+        });
+
+        request.setTimeout(60_000, () => {
+            request.destroy();
+            reject(new Error('Download timed out'));
+        });
+    });
+}
+
+export function getCachedVersions(): Record<string, string[]> {
+    const root = path.join(app.getPath('userData'), 'firmware');
+    const result: Record<string, string[]> = {};
+
+    if (!fs.existsSync(root)) return result;
+
+    for (const ecuId of fs.readdirSync(root)) {
+        const ecuDir = path.join(root, ecuId);
+        if (!fs.statSync(ecuDir).isDirectory()) continue;
+        result[ecuId] = fs.readdirSync(ecuDir).filter((tag) => {
+            return fs.existsSync(path.join(ecuDir, tag, 'fw.bin'));
+        });
+    }
+
+    return result;
+}
+
+export function getFirmwareLocalUrl(ecuId: EcuId, tag: string): string {
+    const bindAddress = getBindAddress();
+    return `http://${bindAddress}:${FIRMWARE_SERVER_PORT}/firmware/${ecuId}/${tag}/fw.bin`;
+}

--- a/infotainment/headunit/src/helpers/ipc/firmware/firmware-server.ts
+++ b/infotainment/headunit/src/helpers/ipc/firmware/firmware-server.ts
@@ -1,0 +1,93 @@
+import * as http from 'http';
+import * as fs from 'fs';
+import * as path from 'path';
+import { app } from 'electron';
+import log from 'electron-log/main';
+import { getBindAddress } from '@/helpers/ipc/hardware/network-config';
+import { FIRMWARE_SERVER_PORT } from '@/data/config';
+
+let currentServer: http.Server | null = null;
+
+function getFirmwareCacheRoot(): string {
+    return path.join(app.getPath('userData'), 'firmware');
+}
+
+export function startFirmwareServer(): void {
+    const bindAddress = getBindAddress();
+    const cacheRoot = getFirmwareCacheRoot();
+
+    const server = http.createServer((req, res) => {
+        if (!req.url) {
+            res.writeHead(400);
+            res.end('Bad Request');
+            return;
+        }
+
+        // Expected path: /firmware/:ecuId/:tag/fw.bin
+        const match = req.url.match(/^\/firmware\/([^/]+)\/([^/]+)\/fw\.bin$/);
+        if (!match) {
+            res.writeHead(404);
+            res.end('Not Found');
+            return;
+        }
+
+        const [, ecuId, tag] = match;
+        const filePath = path.join(cacheRoot, ecuId, tag, 'fw.bin');
+
+        if (!fs.existsSync(filePath)) {
+            res.writeHead(404);
+            res.end('Firmware not found');
+            return;
+        }
+
+        const stat = fs.statSync(filePath);
+        res.writeHead(200, {
+            'Content-Type': 'application/octet-stream',
+            'Content-Length': stat.size,
+            'Content-Disposition': `attachment; filename="${ecuId}_${tag}.bin"`,
+        });
+
+        const stream = fs.createReadStream(filePath);
+        stream.on('error', (err) => {
+            log.error(`[firmware-server] Error streaming file ${filePath}:`, err.message);
+            res.end();
+        });
+        stream.pipe(res);
+
+        log.info(`[firmware-server] Served ${filePath} to ${req.socket.remoteAddress}`);
+    });
+
+    currentServer = server;
+
+    server.listen(FIRMWARE_SERVER_PORT, bindAddress, () => {
+        log.info(`[firmware-server] Running on http://${bindAddress}:${FIRMWARE_SERVER_PORT}`);
+    });
+
+    server.on('error', (err) => {
+        log.error(`[firmware-server] Error: ${err.message}`);
+    });
+}
+
+export function stopFirmwareServer(): Promise<void> {
+    return new Promise((resolve, reject) => {
+        if (!currentServer) {
+            resolve();
+            return;
+        }
+        currentServer.close((err) => {
+            if (err) {
+                log.error(`[firmware-server] Error stopping: ${err.message}`);
+                reject(err);
+            } else {
+                log.info('[firmware-server] Stopped');
+                currentServer = null;
+                resolve();
+            }
+        });
+    });
+}
+
+export async function restartFirmwareServer(): Promise<void> {
+    await stopFirmwareServer();
+    startFirmwareServer();
+}

--- a/infotainment/headunit/src/helpers/ipc/firmware/github-releases.ts
+++ b/infotainment/headunit/src/helpers/ipc/firmware/github-releases.ts
@@ -1,0 +1,89 @@
+import https from 'https';
+import log from 'electron-log/main';
+import { FirmwareRelease } from '@/data/ecu/ecu-types';
+
+const GITHUB_REPO = 'mad201802/asl-gokart';
+const CACHE_TTL_MS = 5 * 60 * 1000; // 5 minutes
+
+interface CacheEntry {
+    releases: FirmwareRelease[];
+    fetchedAt: number;
+}
+
+const cache = new Map<string, CacheEntry>();
+
+function fetchJson<T>(url: string): Promise<T> {
+    return new Promise((resolve, reject) => {
+        const req = https.get(
+            url,
+            {
+                headers: {
+                    'User-Agent': 'asl-gokart-headunit',
+                    'Accept': 'application/vnd.github+json',
+                },
+            },
+            (res) => {
+                const chunks: Buffer[] = [];
+                res.on('data', (chunk: Buffer) => chunks.push(chunk));
+                res.on('end', () => {
+                    try {
+                        const body = Buffer.concat(chunks).toString('utf-8');
+                        resolve(JSON.parse(body) as T);
+                    } catch (err) {
+                        reject(err);
+                    }
+                });
+            }
+        );
+        req.on('error', reject);
+        req.setTimeout(10_000, () => {
+            req.destroy();
+            reject(new Error('GitHub API request timed out'));
+        });
+    });
+}
+
+interface GitHubRelease {
+    tag_name: string;
+    name: string;
+    prerelease: boolean;
+    published_at: string;
+    assets: {
+        name: string;
+        browser_download_url: string;
+    }[];
+}
+
+export async function fetchReleases(assetName: string): Promise<FirmwareRelease[]> {
+    const cached = cache.get(assetName);
+    if (cached && Date.now() - cached.fetchedAt < CACHE_TTL_MS) {
+        log.debug(`[github-releases] Returning cached releases for ${assetName}`);
+        return cached.releases;
+    }
+
+    log.info(`[github-releases] Fetching releases from GitHub for asset: ${assetName}`);
+
+    const url = `https://api.github.com/repos/${GITHUB_REPO}/releases`;
+    const ghReleases = await fetchJson<GitHubRelease[]>(url);
+
+    const releases: FirmwareRelease[] = ghReleases
+        .filter((r) => r.assets.some((a) => a.name === assetName))
+        .map((r) => {
+            const asset = r.assets.find((a) => a.name === assetName)!;
+            return {
+                tag: r.tag_name,
+                version: r.tag_name,
+                publishedAt: r.published_at,
+                downloadUrl: asset.browser_download_url,
+                isPrerelease: r.prerelease,
+            };
+        });
+
+    cache.set(assetName, { releases, fetchedAt: Date.now() });
+    log.info(`[github-releases] Found ${releases.length} release(s) for ${assetName}`);
+    return releases;
+}
+
+export function invalidateCache(): void {
+    cache.clear();
+}

--- a/infotainment/headunit/src/helpers/ipc/hardware/hardware-listeners.tsx
+++ b/infotainment/headunit/src/helpers/ipc/hardware/hardware-listeners.tsx
@@ -9,6 +9,7 @@ import os from "os";
 import { getStoredMac, setStoredMac, getCurrentInterface, resolveInterfaceByMac } from "./network-config";
 import { restartWebSocketServer } from "@/helpers/ipc/websocket/ws-server";
 import { restartSeroService } from "@/helpers/ipc/sero/sero-service";
+import { restartFirmwareServer } from "@/helpers/ipc/firmware/firmware-server";
 
 export function registerHardwareListeners() {
     ipcMain.handle(GET_AVAILABLE_NETWORK_INTERFACES_CHANNEL, async () => {
@@ -35,6 +36,7 @@ export function registerHardwareListeners() {
 
         await restartWebSocketServer();
         restartSeroService();
+        await restartFirmwareServer();
 
         log.info(`[hardware] Services restarted on interface ${resolved.name} (${resolved.address})`);
         return getCurrentInterface();

--- a/infotainment/headunit/src/helpers/ipc/listeners-register.ts
+++ b/infotainment/headunit/src/helpers/ipc/listeners-register.ts
@@ -9,6 +9,8 @@ import { Zones } from "@/data/zonecontrollers/zonecontrollers";
 import { addAppEventListeners } from "./application/app-listeners";
 import { registerSeroHandlers, startSeroService } from "./sero/sero-service";
 import { registerHardwareListeners } from "./hardware/hardware-listeners";
+import { registerFirmwareListeners } from "./firmware/firmware-listeners";
+import { startFirmwareServer } from "./firmware/firmware-server";
 
 export default function registerListeners(mainWindow: BrowserWindow) {
     addWindowEventListeners(mainWindow);
@@ -18,6 +20,8 @@ export default function registerListeners(mainWindow: BrowserWindow) {
     registerSeroHandlers();
     addAppEventListeners();
     registerHardwareListeners();
+    startFirmwareServer();
+    registerFirmwareListeners();
 
     ipcMain.on(WEBSOCKET_SEND_CHANNEL, (event, message: OutgoingPacket, zoneToSendTo: Zones) => {
         // Send the message to the zone controller matching the specified zone

--- a/infotainment/headunit/src/lib/types/ipc.d.ts
+++ b/infotainment/headunit/src/lib/types/ipc.d.ts
@@ -48,6 +48,22 @@ interface HardwareContext {
     setNetworkInterface: (mac: string) => Promise<ResolvedInterface | null>;
 }
 
+interface FirmwareRelease {
+    tag: string;
+    version: string;
+    publishedAt: string;
+    downloadUrl: string;
+    isPrerelease: boolean;
+}
+
+interface FirmwareContext {
+    getReleases: (assetName: string) => Promise<FirmwareRelease[]>;
+    downloadFirmware: (ecuId: string, tag: string, downloadUrl: string) => Promise<{ localUrl: string }>;
+    triggerOta: (ecuId: string, tag: string) => Promise<{ success: boolean; url: string }>;
+    getServerBaseUrl: () => Promise<string>;
+    getCachedVersions: () => Promise<Record<string, string[]>>;
+}
+
 declare global {
     interface Window {
         themeMode: ThemeModeContext;
@@ -56,5 +72,6 @@ declare global {
         sero: SeroContext;
         app: AppContext;
         hardware: HardwareContext;
+        firmware: FirmwareContext;
     }
 }

--- a/infotainment/headunit/src/pages/ecu-manager.tsx
+++ b/infotainment/headunit/src/pages/ecu-manager.tsx
@@ -1,0 +1,47 @@
+import React from "react";
+import { HeaderBar } from "@/components/shared/header-bar";
+import { Button } from "@/components/ui/button";
+import { Separator } from "@/components/ui/separator";
+import { ChevronLeft } from "lucide-react";
+import { useNavigate } from "react-router-dom";
+import { ECU_DEFINITIONS } from "@/data/ecu/ecu-definitions";
+import { EcuCard } from "@/components/ecu/ecu-card";
+
+const EcuManagerPage = () => {
+    const navigate = useNavigate();
+
+    return (
+        <div className="w-full h-full flex flex-col">
+            <HeaderBar />
+
+            <div className="flex items-center gap-3 px-4 py-3 border-b">
+                <Button
+                    variant="ghost"
+                    size="icon"
+                    onClick={() => navigate("/settings")}
+                    className="shrink-0"
+                >
+                    <ChevronLeft className="h-5 w-5" />
+                </Button>
+                <div className="min-w-0">
+                    <h1 className="text-base font-semibold leading-tight">ECU Manager</h1>
+                    <p className="text-xs text-muted-foreground">
+                        Flash firmware to zone controllers over LAN (OTA)
+                    </p>
+                </div>
+            </div>
+
+            <Separator />
+
+            <div className="flex-1 overflow-y-auto p-4">
+                <div className="grid grid-cols-2 gap-4">
+                    {ECU_DEFINITIONS.map((def) => (
+                        <EcuCard key={def.id} definition={def} />
+                    ))}
+                </div>
+            </div>
+        </div>
+    );
+};
+
+export default EcuManagerPage;

--- a/infotainment/headunit/src/pages/settings.tsx
+++ b/infotainment/headunit/src/pages/settings.tsx
@@ -18,10 +18,11 @@ import log, { setRendererLogLevel, type LogLevel } from "@/lib/logger";
 import { AnalyticsBackendDialog } from "@/components/settings/analytics-backend-dialog";
 import { AdminAuthDialog } from "@/components/admin-mode/admin-auth-dialog";
 import { NetworkInterfaceDialog } from "@/components/settings/network-interface-dialog";
+import { useNavigate } from "react-router-dom";
 
 const SettingsPage = () => {
 
-  const { driveMode, speedLimit, minSettableSpeed, maxSettableSpeed, appVersion, analyticsEnabled, logLevel, setDriveMode, setSpeedLimit, setAppVersion, setAnalyticsEnabled, setLogLevel } = useStore(
+  const { driveMode, speedLimit, minSettableSpeed, maxSettableSpeed, appVersion, analyticsEnabled, logLevel, adminMode, setDriveMode, setSpeedLimit, setAppVersion, setAnalyticsEnabled, setLogLevel } = useStore(
     useShallow((state) => ({
       driveMode: state.driveMode,
       speedLimit: state.speedLimit,
@@ -30,6 +31,7 @@ const SettingsPage = () => {
       appVersion: state.appVersion,
       analyticsEnabled: state.analyticsEnabled,
       logLevel: state.logLevel,
+      adminMode: state.adminMode,
       setDriveMode: state.setDriveMode,
       setSpeedLimit: state.setSpeedLimit,
       setAppVersion: state.setAppVersion,
@@ -37,6 +39,8 @@ const SettingsPage = () => {
       setLogLevel: state.setLogLevel,
     }))
   );
+
+  const navigate = useNavigate();
 
   useEffect(() => {
     const fetchAppVersion = async () => {
@@ -137,6 +141,15 @@ const SettingsPage = () => {
           <div className="flex flex-row justify-between items-center space-x-4">
               <Label htmlFor="avanced-settings" className="text-base mr-5">Admin Settings</Label>
               <AdminSettingsDialog />
+          </div>
+          <div className="flex flex-row justify-between items-center space-x-4">
+              <Label htmlFor="ecu-manager" className="text-base mr-5">ECU Manager</Label>
+              <Button
+                disabled={!adminMode}
+                onClick={() => navigate('/ecu-manager')}
+              >
+                Open
+              </Button>
           </div>
           <div className="flex flex-row justify-between items-center space-x-4">
             <Label htmlFor="max-speed" className="text-base mr-5">Max. Speed</Label>


### PR DESCRIPTION
This pull request introduces a new ECU Manager feature to the infotainment headunit, enabling firmware management (viewing, downloading, and flashing) for ECUs directly from the UI. It includes new UI components, IPC context exposure for firmware operations, and supporting data structures for ECUs and firmware releases.

**ECU Manager Feature & UI Components:**

* Added a new `EcuManagerPage` and corresponding route (`/ecu-manager`) to the application, allowing users to manage ECUs and their firmware. (`infotainment/headunit/src/App.tsx`) [[1]](diffhunk://#diff-83f007804842e0980a2bbf65efb91c4845abdefedc325c01618c137f4e6bb475R15) [[2]](diffhunk://#diff-83f007804842e0980a2bbf65efb91c4845abdefedc325c01618c137f4e6bb475R76)
* Implemented `EcuCard` and `EcuUpdateDialog` components for displaying ECU details and handling firmware selection, download, and flashing operations, including status and error handling. (`infotainment/headunit/src/components/ecu/ecu-card.tsx`, `infotainment/headunit/src/components/ecu/ecu-update-dialog.tsx`) [[1]](diffhunk://#diff-e90c047343c6c541ba8bc1120180be6100e44b2e12d0c6c5baf8f090a5af3e57R1-R46) [[2]](diffhunk://#diff-5e895098e804c6cb09db69a0906d7a0a85b90eea144c5f0ab13293f9cf0b298bR1-R258)
* Added a reusable `Badge` UI component for status indicators. (`infotainment/headunit/src/components/ui/badge.tsx`)

**ECU & Firmware Data Structures:**

* Defined `EcuDefinition`, `FirmwareRelease`, and OTA-related types and enums for representing ECUs and firmware update states. (`infotainment/headunit/src/data/ecu/ecu-types.ts`)
* Created a mock list of ECUs in `ECU_DEFINITIONS` for use until real telemetry is available. (`infotainment/headunit/src/data/ecu/ecu-definitions.ts`)

**Firmware IPC Context & Channels:**

* Exposed a new firmware context to the renderer process, providing IPC methods for firmware release fetching, downloading, OTA triggering, and cached version retrieval. (`infotainment/headunit/src/helpers/ipc/firmware/firmware-context.ts`, `infotainment/headunit/src/helpers/ipc/context-exposer.ts`) [[1]](diffhunk://#diff-13e813a42caa878dff55c1795677f2a7edd50ba264fc91ba43577067900dd1eeR1-R29) [[2]](diffhunk://#diff-e550184619e1712f3c7613f38dade0633234c884ba7b8ee691f9fe5d579b0171R7) [[3]](diffhunk://#diff-e550184619e1712f3c7613f38dade0633234c884ba7b8ee691f9fe5d579b0171R16)
* Defined corresponding firmware IPC channel constants. (`infotainment/headunit/src/helpers/ipc/firmware/firmware-channels.ts`)

**Configuration:**

* Added a configuration constant for the firmware HTTP file server port. (`infotainment/headunit/src/data/config.ts`)