### PR TITLE
Feature/fix zc lights

### DIFF
--- a/infotainment/headunit/src/helpers/ipc/sero/sero-service.ts
+++ b/infotainment/headunit/src/helpers/ipc/sero/sero-service.ts
@@ -106,7 +106,7 @@ function handleLightsCommand(command: LightsCommands, value?: any) {
             rt.fireAndForget(0x0001, 0x0004);
             break;
         case LightsCommands.SET_TOGGLE_HEADLIGHTS:
-            rt.fireAndForget(0x0001, 0x0005);
+            rt.fireAndForget(0x0001, 0x0009);
             break;
         case LightsCommands.SET_TOGGLE_HIGH_BEAMS:
             rt.fireAndForget(0x0001, 0x0006);

--- a/infotainment/headunit/src/hooks/useLightsData.ts
+++ b/infotainment/headunit/src/hooks/useLightsData.ts
@@ -17,9 +17,9 @@ export function useLightsData() {
             const parsed: IncomingPacket = JSON.parse(incomingPacket);
             switch (parsed.command) {
                 case LightsCommands.GET_TURN_SIGNAL_LIGHTS:
-                    setTurnSignalLeft(parsed.value[0]);
+                    setTurnSignalLeft(parsed.value[0] === 1);
                     setHazardLights(parsed.value[0] === 1 && parsed.value[1] === 1);
-                    setTurnSignalRight(parsed.value[1]);
+                    setTurnSignalRight(parsed.value[1] === 1);
                     break;
                 case LightsCommands.GET_HEADLIGHTS:
                     setHeadlights([parsed.value[0] === 1, parsed.value[1] === 1]);

--- a/zc/zc_buttons/src/config.hpp
+++ b/zc/zc_buttons/src/config.hpp
@@ -39,7 +39,7 @@ struct Esp32ServiceConfig {
     static constexpr uint16_t ZC_LIGHTS_LEFT_ID         = 0x0002;
     static constexpr uint16_t ZC_LIGHTS_RIGHT_ID        = 0x0003;
     static constexpr uint16_t ZC_LIGHTS_HAZARD_ID       = 0x0004;
-    static constexpr uint16_t ZC_LIGHTS_HEADLIGHTS_ID   = 0x0005;
+    static constexpr uint16_t ZC_LIGHTS_DRL_ID          = 0x0009;
     static constexpr uint16_t ZC_LIGHTS_HIGH_BEAMS_ID   = 0x0006;
 
     // zc_buttons own service (provider side — exposes OTA method to headunit)

--- a/zc/zc_buttons/src/main.cpp
+++ b/zc/zc_buttons/src/main.cpp
@@ -249,7 +249,7 @@ void loop() {
         }
         if (button4.pressed()) {
             uint8_t payload[1] = {0x04};
-            rt.request(Esp32ServiceConfig::ZC_LIGHTS_ID, Esp32ServiceConfig::ZC_LIGHTS_HEADLIGHTS_ID,
+            rt.request(Esp32ServiceConfig::ZC_LIGHTS_ID, Esp32ServiceConfig::ZC_LIGHTS_DRL_ID,
                        payload, sizeof(payload), on_lights_response, nullptr, 2000, now);
             Serial.println("Button 4 pressed - method call sent");
         }

--- a/zc/zc_lights/src/config.hpp
+++ b/zc/zc_lights/src/config.hpp
@@ -93,8 +93,8 @@ struct Esp32HwConfig {
 struct RearLightBarConfig {
     // Matrix dimensions
     static constexpr uint16_t WIDTH    = 144;
-    static constexpr uint16_t HEIGHT   = 4;
-    static constexpr uint16_t NUM_LEDS = WIDTH * HEIGHT; // 576
+    static constexpr uint16_t HEIGHT   = 3;
+    static constexpr uint16_t NUM_LEDS = WIDTH * HEIGHT; // 432
 
     // ── Zone boundaries (column indices) ────────────────────────
     // Turn signal zones: 36 columns from each end
@@ -133,16 +133,16 @@ struct RearLightBarConfig {
 
     // ── Colors ──────────────────────────────────────────────────
     inline static const RgbColor COLOR_OFF     = RgbColor(  0,   0,   0);
-    inline static const RgbColor COLOR_TAIL    = RgbColor(255,   0,   0);
-    inline static const RgbColor COLOR_BRAKE   = RgbColor(255,   0,   0);
-    inline static const RgbColor COLOR_TURN    = RgbColor(255,  40,   0);
+    inline static const RgbColor COLOR_TAIL    = RgbColor(  0, 255,   0);
+    inline static const RgbColor COLOR_BRAKE   = RgbColor(  0, 255,   0);
+    inline static const RgbColor COLOR_TURN    = RgbColor(40,  255,   0);
     inline static const RgbColor COLOR_REVERSE = RgbColor(255, 255, 255);
 };
 
 // ── Front DRL Strip Configuration ───────────────────────────────
 struct FrontDrlConfig {
     // Strip dimensions (1D)
-    static constexpr uint16_t NUM_LEDS = 36;
+    static constexpr uint16_t NUM_LEDS = 10;
 
     // ── Animation timing ────────────────────────────────────────
     static constexpr uint32_t BLINK_SWEEP_DURATION_MS  = 400;
@@ -150,8 +150,8 @@ struct FrontDrlConfig {
     static constexpr uint32_t WELCOME_GLOW_DURATION_MS = 1500;
 
     // ── Brightness defaults ─────────────────────────────────────
-    static constexpr uint8_t BRIGHTNESS_DRL  = 200;
-    static constexpr uint8_t BRIGHTNESS_TURN = 255;
+    static constexpr uint8_t BRIGHTNESS_DRL  = 128;
+    static constexpr uint8_t BRIGHTNESS_TURN = 128;
 
     // ── Colors ──────────────────────────────────────────────────
     inline static const RgbColor COLOR_OFF     = RgbColor(  0,   0,   0);

--- a/zc/zc_lights/src/front_drl_controller.hpp
+++ b/zc/zc_lights/src/front_drl_controller.hpp
@@ -40,6 +40,9 @@ public:
     /// Callback fired when the turn-signal state changes: 1 = on, 0 = off.
     using TurnStateFn = std::function<void(uint8_t on)>;
 
+    /// Callback fired when the DRL state changes: 1 = on, 0 = off.
+    using DrlStateFn = std::function<void(uint8_t on)>;
+
     /// @param pin           GPIO data-line for this strip.
     /// @param num_leds      LED count (default from config).
     /// @param sweep_forward true = sweep left-to-right (right strip),
@@ -83,9 +86,13 @@ public:
     /// If a turn signal is active the visual change is deferred until it ends.
     void set_drl(bool on) {
         xSemaphoreTake(mutex_, portMAX_DELAY);
+        const bool changed = (drl_on_ != on);
         drl_on_ = on;
-        Serial.printf("[%s] DRL %s\n", task_name_, on ? "ON" : "OFF");
         xSemaphoreGive(mutex_);
+        if (changed && drl_callback_) {
+            drl_callback_(on ? 1 : 0);
+        }
+        Serial.printf("[%s] DRL %s\n", task_name_, on ? "ON" : "OFF");
         notify_task();
     }
 
@@ -141,6 +148,9 @@ public:
     /// Register a callback that fires whenever the turn-signal state changes.
     void set_turn_callback(TurnStateFn fn) { turn_callback_ = std::move(fn); }
 
+    /// Register a callback that fires whenever the DRL state changes.
+    void set_drl_callback(DrlStateFn fn) { drl_callback_ = std::move(fn); }
+
 private:
     // ── Constants ───────────────────────────────────────────────────────────
     static constexpr uint32_t FRAME_INTERVAL_MS  = 20;  // ~50 fps
@@ -169,6 +179,7 @@ private:
     // ── Callback ────────────────────────────────────────────────────────────
     TurnStateFn  turn_callback_;
     uint8_t      last_turn_state_;
+    DrlStateFn   drl_callback_;
 
     // ── Mode resolution ─────────────────────────────────────────────────────
     /// Determine the current visual mode according to priority rules.

--- a/zc/zc_lights/src/main.cpp
+++ b/zc/zc_lights/src/main.cpp
@@ -176,6 +176,15 @@ void setup() {
                                   payload, 2);
     });
 
+    // Front DRL: DRL state
+    front_drl_left.set_drl_callback([](uint8_t on) {
+        if (!runtime_ptr) return;
+        uint8_t payload[1] = { on };
+        runtime_ptr->notify_event(Esp32ServiceConfig::ZC_LIGHTS_ID,
+                                  Esp32ServiceConfig::ZC_LIGHTS_EVENT_DRL_STATE_ID,
+                                  payload, 1);
+    });
+
     // ── Register and offer LightsService ────────────────────────
 
     static LightsService<FrontLeftMethod, FrontRightMethod> lights_svc(

--- a/zc/zc_lights/src/rear_light_bar_controller.hpp
+++ b/zc/zc_lights/src/rear_light_bar_controller.hpp
@@ -247,9 +247,14 @@ private:
 
     /// Emit turn callback only when the logical state actually changes.
     void maybe_emit_turn(uint8_t left, uint8_t right) {
-        if (turn_cb_ && (left != last_turn_left_ || right != last_turn_right_)) {
+        xSemaphoreTake(mutex_, portMAX_DELAY);
+        const bool changed = (left != last_turn_left_ || right != last_turn_right_);
+        if (changed) {
             last_turn_left_  = left;
             last_turn_right_ = right;
+        }
+        xSemaphoreGive(mutex_);
+        if (changed && turn_cb_) {
             turn_cb_(left, right);
         }
     }
@@ -416,6 +421,7 @@ private:
             if (snap.turn == BlinkerState::OFF) {
                 self->render_frame(snap, /*sweep_active=*/false, 0);
                 self->strip_->Show();
+                self->maybe_emit_turn(0, 0);
 
                 // Sleep until state changes.
                 xTaskNotifyWait(0, ULONG_MAX, nullptr, portMAX_DELAY);
@@ -425,6 +431,10 @@ private:
             // ── Animated mode (turn / hazard active) ────────────────────
             const uint32_t sweep_ms = Cfg::BLINK_SWEEP_DURATION_MS;
             const uint32_t off_ms   = Cfg::BLINK_OFF_DURATION_MS;
+
+            const bool do_left  = (snap.turn == BlinkerState::LEFT  || snap.turn == BlinkerState::HAZARD);
+            const bool do_right = (snap.turn == BlinkerState::RIGHT || snap.turn == BlinkerState::HAZARD);
+            self->maybe_emit_turn(do_left ? 1 : 0, do_right ? 1 : 0);
 
             // ── Sweep ON phase ──────────────────────────────────────────
             const uint32_t sweep_start = millis();
@@ -471,6 +481,8 @@ private:
             // ── OFF phase ───────────────────────────────────────────────
             snap = self->snapshot_state();
             if (snap.turn == BlinkerState::OFF) continue;
+
+            self->maybe_emit_turn(0, 0);
 
             // Render with sweep_active=false so turn zones show underlying
             // state (or off if nothing else is active).


### PR DESCRIPTION
This pull request introduces several updates to the lighting system, affecting both the headunit software and the embedded controllers. The main changes include improvements to state handling and callbacks for the DRL (Daytime Running Lights), updates to protocol IDs, and configuration adjustments for the LED hardware and colors.

**Lighting Protocol and Callback Enhancements:**

* Added a callback mechanism in `FrontDrlController` to notify when the DRL state changes, and integrated this into the main setup to emit events to the runtime (`zc/zc_lights/src/front_drl_controller.hpp`, `zc/zc_lights/src/main.cpp`). [[1]](diffhunk://#diff-cfaa7d8d08d4b32a991b327e8e0f4639c3a212003b6064564b5b97a1c4cd5814R43-R45) [[2]](diffhunk://#diff-cfaa7d8d08d4b32a991b327e8e0f4639c3a212003b6064564b5b97a1c4cd5814R89-R95) [[3]](diffhunk://#diff-cfaa7d8d08d4b32a991b327e8e0f4639c3a212003b6064564b5b97a1c4cd5814R151-R153) [[4]](diffhunk://#diff-cfaa7d8d08d4b32a991b327e8e0f4639c3a212003b6064564b5b97a1c4cd5814R182) [[5]](diffhunk://#diff-e99858a979480b52a610f3dad8accf2529ad8ccc5a89833292ce76986c7bff5aR179-R187)
* Improved turn signal state handling in `RearLightBarController` by ensuring callbacks are only fired on actual state changes, and added synchronization for thread safety (`zc/zc_lights/src/rear_light_bar_controller.hpp`). [[1]](diffhunk://#diff-e222596538719a198565cf249a2a7420edd578e7f9a8ae982c6291fcf26b367aL250-R257) [[2]](diffhunk://#diff-e222596538719a198565cf249a2a7420edd578e7f9a8ae982c6291fcf26b367aR424) [[3]](diffhunk://#diff-e222596538719a198565cf249a2a7420edd578e7f9a8ae982c6291fcf26b367aR435-R438) [[4]](diffhunk://#diff-e222596538719a198565cf249a2a7420edd578e7f9a8ae982c6291fcf26b367aR485-R486)

**Protocol and Command ID Updates:**

* Changed the protocol ID for toggling headlights from `0x0005` to `0x0009` in both the headunit and embedded configs to align with DRL control, and updated button handling accordingly (`infotainment/headunit/src/helpers/ipc/sero/sero-service.ts`, `zc/zc_buttons/src/config.hpp`, `zc/zc_buttons/src/main.cpp`). [[1]](diffhunk://#diff-2ffe304aec3b1b2471edc0f105aff13ebad2b764988a27b69e1c13efb2f82f6bL109-R109) [[2]](diffhunk://#diff-c5551bce42459c4603e954f2044f3e2dc245515aa97cd522865413ee20835fd3L42-R42) [[3]](diffhunk://#diff-f6af25b625b9a6b34f20e09458a99ae0628374b6c9815e6745287cc89803bb60L252-R252)

**LED Hardware and Color Configuration:**

* Updated the rear light bar configuration: reduced matrix height from 4 to 3 and adjusted the number of LEDs accordingly; changed the default colors for tail, brake, and turn signals to new RGB values (`zc/zc_lights/src/config.hpp`). [[1]](diffhunk://#diff-6fd3b2ad94d09523b52dcffa4d7c85cd9a3f8b03c1a20ceeddd36124553ef271L96-R97) [[2]](diffhunk://#diff-6fd3b2ad94d09523b52dcffa4d7c85cd9a3f8b03c1a20ceeddd36124553ef271L136-R154)
* Modified the front DRL strip configuration: reduced the number of LEDs from 36 to 10 and lowered the default brightness for both DRL and turn signals (`zc/zc_lights/src/config.hpp`).

**Headunit Data Handling:**

* Improved parsing of turn signal and hazard light states in the headunit hook to use boolean logic for state updates (`infotainment/headunit/src/hooks/useLightsData.ts`).